### PR TITLE
feat: allow adding custom IAM policy to ECS IAM role

### DIFF
--- a/aws/connector-without-permissions/stacks/apono-connector/cdk.tf.json
+++ b/aws/connector-without-permissions/stacks/apono-connector/cdk.tf.json
@@ -150,6 +150,10 @@
           {
             "name": "apono-cloudtrail-logs-s3-access-policy",
             "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::aws-cloudtrail-logs-apono-*/*\"}],\"Version\":\"2012-10-17\"}"
+          },
+          {
+            "name": "apono-additional-custom-policy",
+            "policy": "${var.additional_iam_policy}"
           }
         ],
         "managed_policy_arns": [
@@ -273,6 +277,13 @@
     "vpcId": [
       {
         "type": "string"
+      }
+    ],
+    "additional_iam_policy": [
+      {
+        "description": "Optional custom IAM policy to assign to connector ECS task role",
+        "type": "string",
+        "default": "{}"
       }
     ]
   }


### PR DESCRIPTION
**What**: Allow module users to be able to extend permissions of ECS task role.

**How**: Add optional variable that will expect `data.aws_iam_policy_document.**.json` string, and if any, it will add it to the set of policies of the ECS IAM role

**Why**: There is no way to modify IAM role policies of ECS task, as it's using IAM Role terraform resource's `managed_policy_arns` and `inline_policy` configuration blocks that prevent's from any changes to happen outside of it. If you attempt to add policies using e.g. [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) resource, the next terraform plan, after you apply the new policy, will try to remove it and go back to what's hardcoded in the module. See more [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)

<img width="677" alt="image" src="https://github.com/user-attachments/assets/20b1b3e2-ef23-4a64-afc8-4d3bb3f6d665" />

**Example usage**

```
data "aws_iam_policy_document" "custom_apono_policy" {
    statement {
        effect = "Allow"
        actions = [
          "rds-db:connect"
        ]
        resources = [
           "*"
        ]
    }
}
        
module "apono_connector" {
    source = "github.com/apono-io/terraform-modules//aws/connector-without-permissions/stacks/apono-connector"

    ....
    
    additional_iam_policy = data.aws_iam_policy_document.custom_apono_policy.json
}
```

**... or switch to `aws_iam_role_policy` instead**

Another option, that would also get rid of the below warning, is to indeed switch to `aws_iam_role_policy` resource.

```
│ Warning: Argument is deprecated
│
│   with module.apono_connector.aws_iam_role.IAMRole,
│   on ../../../../../../modules/apono-connector/cdk.tf.json line 133, in resource.aws_iam_role.IAMRole:
│  133:         "inline_policy": [
│  134:           {
│  135:             "name": "remote-management",
│  136:             "policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"assume\"}],\"Version\":\"2012-10-17\"}"
│  137:           },
....
│
│ The inline_policy argument is deprecated. Use the aws_iam_role_policy resource instead. If Terraform should exclusively manage all inline policy
│ associations (the current behavior of this argument), use the aws_iam_role_policies_exclusive resource as well.
│
│ (and 2 more similar warnings elsewhere)
```
